### PR TITLE
Check if all the prerequisites are installed

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -62,6 +62,7 @@ Updating files is easy: Either modify them manually or -- what I recommend -- us
 
 Running tests happens with the `run.sh` script.
 Use `run.sh -h` for usage information.
+The script first checks whether the required executables are installed (`go`, `pandoc`, `magick`, `rsvg-convert`) and exits with a clear error message if one of them is missing.
 
 Mediawiki files are used as basis for the test.
 The generated HTML output and the file list, both written to `results/test-<name>/`, are compared to the expected HTML and file list, which are locates directly here next to each `.mediawiki` file.

--- a/integration-tests/run.sh
+++ b/integration-tests/run.sh
@@ -1,5 +1,37 @@
 #!/bin/bash
 
+function checkCommand()
+{
+	# $1 - executable name
+	# $2 - human readable explanation
+	COMMAND_NAME="$1"
+	COMMAND_DESCRIPTION="$2"
+
+	if ! command -v "$COMMAND_NAME" > /dev/null 2>&1
+	then
+		MISSING_REQUIREMENTS+="$COMMAND_NAME ($COMMAND_DESCRIPTION)"$'\n'
+	fi
+}
+
+function checkPrerequisites()
+{
+	MISSING_REQUIREMENTS=""
+
+	checkCommand "go" "build the wiki2book CLI"
+	checkCommand "pandoc" "generate EPUB output in the integration tests"
+	checkCommand "magick" "process downloaded raster images"
+	checkCommand "rsvg-convert" "convert rendered math SVGs to PNGs"
+
+	if [[ "$MISSING_REQUIREMENTS" != "" ]]
+	then
+		echo "Missing prerequisites for the integration tests:"
+		printf "%s" "$MISSING_REQUIREMENTS" | sed '/^$/d; s/^/  - /g'
+		echo
+		echo "Install the missing tools and run the tests again."
+		exit 1
+	fi
+}
+
 if [[ $@ == *--help* || $@ == *-h* ]]
 then
 	cat<<EOF
@@ -10,6 +42,8 @@ Example: ./run.sh bold-italic real-article-Erde
 EOF
 	exit 0
 fi
+
+checkPrerequisites
 
 GLOBAL_START=$(($(date +%s%N)/1000000))
 


### PR DESCRIPTION
I thought I had everything installed and then the integration tests failed and suggested I might have a network connectivity problem. It turned out I was missing `rsvg-convert`.


Before running the integration tests check if all
the prerequisites are installed so we won't see confusing test failures due to missing prerequisites.

